### PR TITLE
Remember last IP selection on application restart

### DIFF
--- a/src/gui/controllers/data_persistence_controller.py
+++ b/src/gui/controllers/data_persistence_controller.py
@@ -45,17 +45,38 @@ class DataPersistenceController:
     def load_ips(self):
         """Load IP addresses and populate the IP combo box"""
         ip_data = self.main_window.file_crypto.load_encrypted_file(self.IP_LIST_FILE)
-        for ip in ip_data.get("ips", []):
+        ips = ip_data.get("ips", [])
+        last_selected_ip = ip_data.get("current_ip", "")
+
+        # Populate the combo box
+        for ip in ips:
             self.main_window.ip_input.addItem(ip)
 
+        # Restore the last selected IP if it exists in the list
+        if last_selected_ip and last_selected_ip in ips:
+            index = self.main_window.ip_input.findText(last_selected_ip)
+            if index >= 0:
+                self.main_window.ip_input.setCurrentIndex(index)
+
     def save_ips(self):
-        """Save current IP addresses to encrypted file"""
+        """Save current IP addresses and selected IP to encrypted file"""
         ips = []
         for i in range(self.main_window.ip_input.count()):
             ips.append(self.main_window.ip_input.itemText(i))
 
-        ip_data = {"ips": ips}
+        current_ip = self.main_window.ip_input.currentText()
+        ip_data = {"ips": ips, "current_ip": current_ip}
         self.main_window.file_crypto.save_encrypted_file(self.IP_LIST_FILE, ip_data)
+
+    def save_current_ip(self):
+        """Save only the currently selected IP (lightweight update)"""
+        current_ip = self.main_window.ip_input.currentText()
+        if current_ip:  # Only save if there's a valid IP selected
+            ip_data = self.main_window.file_crypto.load_encrypted_file(
+                self.IP_LIST_FILE
+            )
+            ip_data["current_ip"] = current_ip
+            self.main_window.file_crypto.save_encrypted_file(self.IP_LIST_FILE, ip_data)
 
     def load_state(self, ip):
         """Load device states for a specific IP"""

--- a/src/gui/window.py
+++ b/src/gui/window.py
@@ -546,6 +546,9 @@ class MainWindow(QMainWindow):
         # Reset ping status when IP changes
         ip = self.ip_input.currentText()
         if ip:
+            # Save the current IP selection for persistence
+            self.data_persistence_controller.save_current_ip()
+
             self.update_ping_status("unknown")
             # Ping immediately when IP changes
             if SecurityValidator.validate_ip_or_hostname(ip):


### PR DESCRIPTION
## 🎯 **Fixes Issue #2**

### **Summary**
Implements IP selection persistence so the GUI remembers the last selected IP address when the application is reopened.

### **Changes Made**
- ✅ **Enhanced IP data structure** to include `current_ip` field
- ✅ **Updated `load_ips()`** to restore last selected IP on startup  
- ✅ **Modified `save_ips()`** to persist current IP selection
- ✅ **Added `save_current_ip()`** method for lightweight updates
- ✅ **Updated `on_ip_changed()`** to save selection when user changes IP
- ✅ **Added validation** to only save non-empty IP selections

### **Implementation Details**
- **Data Storage:** Current IP stored in existing encrypted `ips.enc` file
- **Performance:** Lightweight `save_current_ip()` method for frequent updates
- **Safety:** Validates IP exists in list before auto-selecting
- **Backward Compatibility:** Gracefully handles missing `current_ip` field

### **Testing**
- ✅ **Code Quality:** Black formatting applied
- ✅ **Functionality:** Manual testing shows IP selection persists
- ✅ **Edge Cases:** Handles empty selections and missing data

### **User Experience**
- **Before:** IP selection resets to first item on restart
- **After:** Application remembers and selects last used IP

### **Files Modified**
- `src/gui/controllers/data_persistence_controller.py` - IP persistence logic
- `src/gui/window.py` - IP change event handling

### **Validation Checklist**
- [x] IP selection persists across application restarts
- [x] Handles cases where saved IP no longer exists in list
- [x] Performance impact minimal (lightweight saves)
- [x] Code follows existing patterns and style
- [x] No breaking changes to existing functionality