### PR TITLE
Fix SSH disconnect auto-refresh reconnection issue

### DIFF
--- a/src/gui/controllers/device_management_controller.py
+++ b/src/gui/controllers/device_management_controller.py
@@ -1364,10 +1364,12 @@ class DeviceManagementController(QObject):
         # Use full device refresh to properly handle all device types
         self.load_devices()
 
-        # If SSH is connected, also refresh remote devices
+        # If SSH credentials are available and valid, also refresh remote devices
         if (
             hasattr(self.main_window, "last_ssh_username")
             and self.main_window.last_ssh_username
+            and hasattr(self.main_window, "last_ssh_password")
+            and self.main_window.last_ssh_password
         ):
             self.main_window.ssh_management_controller.refresh_with_saved_credentials()
             self.main_window.append_simple_message(

--- a/src/gui/controllers/ssh_management_controller.py
+++ b/src/gui/controllers/ssh_management_controller.py
@@ -698,6 +698,14 @@ class SSHManagementController:
         if hasattr(self.main_window, "ssh_client"):
             self.main_window.ssh_client = None
 
+        # Clear saved credentials to prevent auto-refresh from reconnecting
+        if hasattr(self.main_window, "last_ssh_username"):
+            self.main_window.last_ssh_username = None
+        if hasattr(self.main_window, "last_ssh_password"):
+            self.main_window.last_ssh_password = None
+        if hasattr(self.main_window, "last_ssh_ip"):
+            self.main_window.last_ssh_ip = None
+
         self.main_window.remote_table.setRowCount(0)
 
         # Hide SSH-related buttons
@@ -706,13 +714,20 @@ class SSHManagementController:
         self.main_window.usbipd_service_button.setVisible(False)
         self.main_window.linux_usbip_service_button.setVisible(False)
 
+        # Notify user of successful disconnect
+        self.main_window.append_simple_message(
+            "🔌 SSH disconnected - auto-refresh will not reconnect"
+        )
+
     def refresh_with_saved_credentials(self):
         """Refresh remote devices using previously saved SSH credentials"""
-        # If you want to use last SSH credentials, store them after successful SSH login
+        # Check if valid SSH credentials are available
         if (
             hasattr(self.main_window, "last_ssh_username")
             and hasattr(self.main_window, "last_ssh_password")
             and hasattr(self.main_window, "last_ssh_accept")
+            and self.main_window.last_ssh_username  # Ensure not None/empty
+            and self.main_window.last_ssh_password  # Ensure not None/empty
         ):
 
             # Instead of saving UI state, save from persistent storage before any operations


### PR DESCRIPTION
## 🐛 **Fixes Issue #4**

### **Problem**
After using SSH Disconnect, auto-refresh would automatically reconnect to SSH without user consent, overriding the intentional disconnect action. Additionally, authentication errors appeared in console during refresh attempts.

### **Root Cause**
The disconnect process only closed the SSH connection but left saved credentials intact:
- ❌ SSH client closed
- ❌ UI cleared  
- ✅ **BUT credentials remained saved**
- ❌ Auto-refresh detected saved credentials and attempted reconnection

### **Solution**
**1. Clear credentials on disconnect:**
- Clear `last_ssh_username`, `last_ssh_password`, and `last_ssh_ip` 
- Prevent auto-refresh from finding stale credentials

**2. Improve auto-refresh validation:**
- Enhanced credential checks before attempting reconnection
- Validate both username AND password are present and valid
- Added defensive programming in `refresh_with_saved_credentials()`

**3. User feedback:**
- Added confirmation message: "SSH disconnected - auto-refresh will not reconnect"

### **Technical Changes**

**SSH Management Controller:**


**Device Management Controller:**


### **User Experience**
- **Before:** Disconnect → Auto-refresh reconnects (confusing)
- **After:** Disconnect → Stays disconnected until manual reconnection (expected)
- **Bonus:** No more authentication error messages in console

### **Testing**
- ✅ SSH disconnect properly clears credentials
- ✅ Auto-refresh respects disconnect state  
- ✅ No authentication errors after disconnect
- ✅ Manual reconnection still works normally
- ✅ Code formatting and quality maintained

Fixes #4